### PR TITLE
fix: generate a runnable backend config for library projects

### DIFF
--- a/mcpify/detect/camel.py
+++ b/mcpify/detect/camel.py
@@ -430,4 +430,11 @@ Focus on practical, usable tools that provide real value."""
                 "config": {"base_url": "http://localhost:8000", "timeout": 30},
             }
         else:
-            return {"type": "python", "config": {"module": "main"}}
+            return {
+                "type": "commandline",
+                "config": {
+                    "command": "python3",
+                    "args": ["main.py"],
+                    "cwd": ".",
+                },
+            }

--- a/mcpify/detect/openai.py
+++ b/mcpify/detect/openai.py
@@ -382,4 +382,11 @@ class OpenaiDetector(BaseDetector):
                 "config": {"base_url": "http://localhost:8000", "timeout": 30},
             }
         else:
-            return {"type": "python", "config": {"module": "main"}}
+            return {
+                "type": "commandline",
+                "config": {
+                    "command": "python3",
+                    "args": ["main.py"],
+                    "cwd": ".",
+                },
+            }

--- a/tests/test_detector_backend_config.py
+++ b/tests/test_detector_backend_config.py
@@ -1,0 +1,34 @@
+"""Detector-generated backend configs must be both valid and runnable."""
+
+import pytest
+
+from mcpify.backend import create_adapter
+from mcpify.detect.base import ProjectInfo
+from mcpify.detect.camel import CamelDetector
+from mcpify.detect.openai import OpenaiDetector
+from mcpify.validate import MCPConfigValidator
+
+
+@pytest.mark.parametrize("detector_cls", [OpenaiDetector, CamelDetector])
+def test_library_backend_config_is_valid_and_runnable(detector_cls: type) -> None:
+    """A library project's generated backend must validate and build an adapter.
+
+    Regression: the library-project default was ``{"type": "python"}``, which
+    ``VALID_BACKEND_TYPES`` does not include and ``create_adapter`` cannot
+    build, so ``mcpify serve`` on a detected library project raised
+    ``ValueError: Unsupported backend type: python``.
+    """
+    info = ProjectInfo(
+        name="lib",
+        description="library project",
+        main_files=["main.py"],
+        readme_content="",
+        project_type="library",
+        dependencies=[],
+    )
+    # `_generate_backend_config_from_content` does not use `self`, so it can be
+    # called unbound — no API key or network needed.
+    backend = detector_cls._generate_backend_config_from_content(None, info)
+
+    assert backend["type"] in MCPConfigValidator.VALID_BACKEND_TYPES
+    create_adapter(backend)  # must not raise


### PR DESCRIPTION
## Summary

When mcpify detects a **library** project, it generates a backend config the tool cannot run, so `mcpify serve` on that config crashes.

Both detectors return this for a library project:

```python
# mcpify/detect/openai.py and mcpify/detect/camel.py
else:
    return {"type": "python", "config": {"module": "main"}}
```

But `"python"` is not a supported backend:

- `MCPConfigValidator.VALID_BACKEND_TYPES` is `["commandline", "http", "websocket"]` — so `mcpify validate` rejects it.
- `create_adapter` (`mcpify/backend.py`) handles only `commandline`, `server`, `http` and otherwise `raise ValueError(f"Unsupported backend type: {backend_type}")`.

So a normal run — detect a library repo, then `mcpify serve` the generated config (also the path the Streamlit UI takes) — fails with `ValueError: Unsupported backend type: python`. The tool emits output it can't consume.

## Fix

Return a runnable `commandline` config, matching what the base detector (`mcpify/detect/base.py`) already uses as its library-project default, and what this same method returns for the `commandline` project type:

```python
else:
    return {
        "type": "commandline",
        "config": {"command": "python3", "args": ["main.py"], "cwd": "."},
    }
```

## Testing

Added `tests/test_detector_backend_config.py`: for each detector, a library-project `ProjectInfo` must produce a backend whose type is in `VALID_BACKEND_TYPES` **and** that `create_adapter` can build.

- With the fix: **2 passed**.
- Reverting the fix: both fail (`"python"` is not a valid type).
- Full suite: **32 passed**, `ruff check` clean.